### PR TITLE
fix: rebrand ttk for 2 samples

### DIFF
--- a/samples/dotnet-csharp-graphdocs-ttk/README.md
+++ b/samples/dotnet-csharp-graphdocs-ttk/README.md
@@ -1,8 +1,8 @@
-# Ingest markdown content from a custom API using C#, .NET and Teams Toolkit for Visual Studio
+# Ingest markdown content from a custom API using C#, .NET and Microsoft 365 Agents Toolkit for Visual Studio
 
 ## Summary
 
-This sample project uses Teams Toolkit for Visual Studio to simplify the process of creating a [Copilot connector](https://learn.microsoft.com/graph/connecting-external-content-connectors-overview) that ingests data from a custom API to Microsoft Graph. It provides an end to end example of creating the connector, ingesting content and refreshing the ingested content on a schedule. It also includes the [simplified admin experience](https://learn.microsoft.com/graph/connecting-external-content-deploy-teams) which means that admins can toggle the connector on and off from the Microsoft Teams admin center.
+This sample project uses Microsoft 365 Agents Toolkit for Visual Studio to simplify the process of creating a [Copilot connector](https://learn.microsoft.com/graph/connecting-external-content-connectors-overview) that ingests data from a custom API to Microsoft Graph. It provides an end to end example of creating the connector, ingesting content and refreshing the ingested content on a schedule. It also includes the [simplified admin experience](https://learn.microsoft.com/graph/connecting-external-content-deploy-teams) which means that admins can toggle the connector on and off from the Microsoft Teams admin center.
 
 ![Markdown content from custom API displayed in Microsoft Search](./assets/content.png)
 
@@ -53,7 +53,7 @@ You can run this sample in two ways:
 ### 3. Prepare Teams App Dependencies
 
 - In Solution Explorer, right-click the `GraphDocsConnector` Azure Functions project
-- Expand the `Teams Toolkit` menu and select `Prepare Teams App Dependencies`
+- Expand the `Microsoft 365 Agents Toolkit` menu and select `Prepare Teams App Dependencies`
 - When prompted, sign in to your Microsoft 365 tenant
 - Wait for all tasks to complete
 
@@ -133,7 +133,7 @@ When the process is complete you will see a table confirming that the connection
 ### 2. Provision resources
 
 - In Solution Explorer, right-click the `GraphDocsConnector` Azure Functions project
-- Expand the `Teams Toolkit` menu and select `Provision in the cloud...`
+- Expand the `Microsoft 365 Agents Toolkit` menu and select `Provision in the cloud...`
 - In the `Provision` dialog, enter the following and select `Provision`
   - **Account**: Select an account which is associated with an active subscription
   - **Subscription**: Select an active subscription from the list
@@ -144,7 +144,7 @@ When the process is complete you will see a table confirming that the connection
 ### 3. Deploy code
 
 - In Solution Explorer, right-click the `GraphDocsConnector` Azure Functions project
-- Expand the `Teams Toolkit` menu and select `Deploy to the Cloud`
+- Expand the `Microsoft 365 Agents Toolkit` menu and select `Deploy to the Cloud`
 - In the warning prompt, select `Deploy` to deploy the function code
 
 ### 4. Enable Copilot connector
@@ -200,7 +200,7 @@ This sample shows how to ingest data from a custom API into your Microsoft 365 t
 
 The sample illustrates the following concepts:
 
-- simplify debugging and provisioning of resources with Teams Toolkit for Visual Studio
+- simplify debugging and provisioning of resources with Microsoft 365 Agents Toolkit for Visual Studio
 - support the ability to toggle the connection status in the Microsoft Teams admin center
 - create external connection schema
 - support full ingestion of data

--- a/samples/dotnet-csharp-graphdocs-ttk/assets/sample.json
+++ b/samples/dotnet-csharp-graphdocs-ttk/assets/sample.json
@@ -2,12 +2,12 @@
     {
       "name": "pnp-graph-connector-dotnet-csharp-graphdocs-ttk",
       "source": "pnp",
-      "title": "Ingest markdown content from a custom API using C#, .NET and Teams Toolkit for Visual Studio",
-      "shortDescription": "This sample project uses Teams Toolkit to simplify the process of creating a Copilot connector that ingests markdown content from a custom API to Microsoft Graph",
+      "title": "Ingest markdown content from a custom API using C#, .NET and Microsoft 365 Agents Toolkit for Visual Studio",
+      "shortDescription": "This sample project uses Microsoft 365 Agents Toolkit to simplify the process of creating a Copilot connector that ingests markdown content from a custom API to Microsoft Graph",
       "url": "https://github.com/pnp/copilot-connectors-samples/tree/main/samples/dotnet-csharp-graphdocs-ttk",
       "downloadUrl": "https://pnp.github.io/download-partial/?url=https://github.com/pnp/copilot-connectors-samples/tree/main/samples/dotnet-csharp-graphdocs-ttk",
       "longDescription": [
-        "This sample project uses Teams Toolkit for Visual Studio to simplify the process of creating a Copilot connector that ingests markdown content from a custom API to Microsoft Graph. It provides an end to end example of creating the connector, ingesting content and refreshing the ingested content on a schedule. It also includes the simplified admin experience which means that admins can toggle the connector on and off from the Microsoft Teams admin center."
+        "This sample project uses Microsoft 365 Agents Toolkit for Visual Studio to simplify the process of creating a Copilot connector that ingests markdown content from a custom API to Microsoft Graph. It provides an end to end example of creating the connector, ingesting content and refreshing the ingested content on a schedule. It also includes the simplified admin experience which means that admins can toggle the connector on and off from the Microsoft Teams admin center."
       ],
       "creationDateTime": "2024-05-03",
       "updateDateTime": "2024-08-13",
@@ -15,7 +15,8 @@
         "Copilot connectors",
         "Microsoft Graph",
         "Microsoft 365 Copilot",
-        "TeamsToolkit"
+        "TeamsToolkit",
+        "Microsoft 365 Agents Toolkit"
       ],
       "metadata": [
         {
@@ -73,8 +74,8 @@
           "url": "https://learn.microsoft.com/graph/connecting-external-content-build-quickstart"
         },
         {
-          "name": "Teams Toolkit for Visual Studio",
-          "description": "Learn more about the Teams Toolkit for Visual Studio.",
+          "name": "Microsoft 365 Agents Toolkit for Visual Studio",
+          "description": "Learn more about the Microsoft 365 Agents Toolkit for Visual Studio.",
           "url": "https://learn.microsoft.com/microsoftteams/platform/toolkit/toolkit-v4/teams-toolkit-fundamentals-vs"
         },
         {

--- a/samples/nodejs-typescript-policies-dc/README.md
+++ b/samples/nodejs-typescript-policies-dc/README.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-This sample project uses Teams Toolkit for Visual Studio Code to simplify the process of creating a [Copilot connector](https://learn.microsoft.com/graph/connecting-external-content-connectors-overview) that ingests data from a custom API to Microsoft Graph. It provides an end to end example of creating the connector, ingesting content and refreshing the ingested content. It also offers a declarative copilot to consume its content.
+This sample project uses Microsoft 365 Agents Toolkit for Visual Studio Code to simplify the process of creating a [Copilot connector](https://learn.microsoft.com/graph/connecting-external-content-connectors-overview) that ingests data from a custom API to Microsoft Graph. It provides an end to end example of creating the connector, ingesting content and refreshing the ingested content. It also offers a declarative copilot to consume its content.
 
 > [!WARNING]  
 > This samples uses private preview capabilities of Copilot for Microsoft 365. You need to have access to the private preview to use this sample.
@@ -25,7 +25,7 @@ Version|Date|Comments
 
 ## Prerequisites
 
-- [Teams Toolkit for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension)
+- [Microsoft 365 Agents Toolkit for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension)
 - [Azure Functions Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurefunctions)
 - [Microsoft 365 Developer tenant](https://developer.microsoft.com/microsoft-365/dev-program) with [uploading custom apps enabled](https://learn.microsoft.com/microsoftteams/platform/m365-apps/prerequisites#prepare-a-developer-tenant-for-testing)
 - [Node@18](https://nodejs.org)
@@ -69,7 +69,7 @@ This sample shows how to ingest data from a custom API into your Microsoft 365 t
 
 The sample illustrates the following concepts:
 
-- simplify debugging and provisioning of resources with Teams Toolkit for Visual Studio code
+- simplify debugging and provisioning of resources with Microsoft 365 Agents Toolkit for Visual Studio code
 - create external connection schema
 - support full ingestion of data
 - visualize the external content in the Policy Management declarative copilot

--- a/samples/nodejs-typescript-policies-dc/appPackage/declarativeCopilot.json
+++ b/samples/nodejs-typescript-policies-dc/appPackage/declarativeCopilot.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://aka.ms/json-schemas/copilot-extensions/v1.0/declarative-copilot.schema.json",
   "name": "${{ DC_NAME }}",
-  "description": "${{ DC_NAME }} created with Teams Toolkit",
-  "instructions": "You are a declarative copilot and were created with Team Toolkit. You are an expert at helping users with their questions about the ${{ CONNECTOR_ID }} connector and will help them in their quest to find the right information. Only consider content coming from connector ${{ CONNECTOR_ID }}. No other data shall be used.",
+  "description": "${{ DC_NAME }} created with Microsoft 365 Agents Toolkit",
+  "instructions": "You are a declarative copilot and were created with Microsoft 365 Agents Toolkit. You are an expert at helping users with their questions about the ${{ CONNECTOR_ID }} connector and will help them in their quest to find the right information. Only consider content coming from connector ${{ CONNECTOR_ID }}. No other data shall be used.",
   "conversation_starters": [
     {
       "title": "BYOD Policy",

--- a/samples/nodejs-typescript-policies-dc/appPackage/manifest.json
+++ b/samples/nodejs-typescript-policies-dc/appPackage/manifest.json
@@ -20,7 +20,7 @@
   },
   "description": {
     "short": "Policy Management Copilot connector",
-    "full": "Teams Toolkit sample for a Policy Management system using Copilot connector"
+    "full": "Microsoft 365 Agents Toolkit sample for a Policy Management system using Copilot connector"
   },
   "accentColor": "#FFFFFF",
   "composeExtensions": [],

--- a/samples/nodejs-typescript-policies-dc/teamsapp.yml
+++ b/samples/nodejs-typescript-policies-dc/teamsapp.yml
@@ -56,7 +56,7 @@ provision:
           parameters: ./infra/azure.parameters.json
           # Required when deploying ARM template
           deploymentName: Create-resources-for-gc
-      # Teams Toolkit will download this bicep CLI version from github for you,
+      # Microsoft 365 Agents Toolkit will download this bicep CLI version from github for you,
       # will use bicep CLI in PATH if you remove this config.
       bicepCliVersion: v0.9.1
 


### PR DESCRIPTION
2 samples left for rebranding: https://github.com/pnp/copilot-connectors-samples/pull/78

https://github.com/pnp/copilot-connectors-samples/issues/84